### PR TITLE
if displayName is not set, use function name as display name

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -66,7 +66,7 @@ function wrapJsxChildren(x) {
 function handleJsx(x, next, seen, indent) {
   if (React.isValidElement(x)) {
     const lastIndent = indent === '' ? '' : indent.replace(/\s\s$/, '')
-    const name = typeof x.type === 'string' ? x.type : (x.type.displayName || 'Unknown')
+    const name = typeof x.type === 'string' ? x.type : (x.type.displayName || x.type.name || 'Unknown')
     const defaultProps = x.type && (typeof x.type.getDefaultProps === 'function')
       ? x.type.getDefaultProps()
       : {}


### PR DESCRIPTION
this way class components and stateless functional components won't be
displayed as <Unknown ... />
